### PR TITLE
Filter furigana on kana-only words

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import InputSection from './components/InputSection';
 import AnalysisResult from './components/AnalysisResult';
 import TranslationSection from './components/TranslationSection';
 import SettingsModal from './components/SettingsModal';
-import { analyzeSentence, TokenData, DEFAULT_API_URL, streamAnalyzeSentence } from './services/api';
+import { analyzeSentence, TokenData, DEFAULT_API_URL, streamAnalyzeSentence, cleanTokenFurigana } from './services/api';
 
 export default function Home() {
   const [currentSentence, setCurrentSentence] = useState('');
@@ -113,7 +113,7 @@ export default function Home() {
             item && typeof item === 'object' && 'word' in item && 'pos' in item
           );
           if (validTokens.length > 0) {
-            return validTokens;
+            return cleanTokenFurigana(validTokens as TokenData[]);
           }
         }
         return [];

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -1,4 +1,5 @@
 // API与分析相关的服务函数
+import { containsKanji } from '../utils/helpers';
 
 export interface TokenData {
   word: string;
@@ -38,6 +39,16 @@ function getHeaders(userApiKey?: string): HeadersInit {
   }
   
   return headers;
+}
+
+// 移除不需要的假名标注
+export function cleanTokenFurigana(tokens: TokenData[]): TokenData[] {
+  return tokens.map((t) => {
+    if (t.furigana && (!containsKanji(t.word) || t.furigana === t.word)) {
+      return { ...t, furigana: undefined };
+    }
+    return t;
+  });
 }
 
 // 分析日语句子
@@ -90,7 +101,9 @@ export async function analyzeSentence(
         if (jsonMatch && jsonMatch[1]) {
           responseContent = jsonMatch[1];
         }
-        return JSON.parse(responseContent) as TokenData[];
+        return cleanTokenFurigana(
+          JSON.parse(responseContent) as TokenData[]
+        );
       } catch (e) {
         console.error("Failed to parse JSON from analysis response:", e, responseContent);
         throw new Error('解析结果JSON格式错误');


### PR DESCRIPTION
## Summary
- avoid showing furigana for words made only of hiragana
- provide helper to remove redundant furigana from token data

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f63501a4832781a986d8102269fa