### PR TITLE
Add GitHub link and domain hint

### DIFF
--- a/app/components/SettingsModal.tsx
+++ b/app/components/SettingsModal.tsx
@@ -60,14 +60,25 @@ export default function SettingsModal({
 
   return (
     <>
-      <button 
-        id="settingsButton" 
+      <button
+        id="settingsButton"
         title="API 设置"
         onClick={onModalClose}
         className="fixed top-6 right-6 z-1000 bg-white text-[#007AFF] border border-[#007AFF] rounded-full w-10 h-10 flex items-center justify-center shadow-md hover:bg-gray-50 transition-all"
       >
         <i className="fas fa-cog"></i>
       </button>
+
+      <a
+        id="githubButton"
+        href="https://github.com/cokice/japanese-analyzer"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="GitHub 仓库"
+        className="fixed top-6 right-20 z-1000 bg-white text-gray-800 border border-gray-800 rounded-full w-10 h-10 flex items-center justify-center shadow-md hover:bg-gray-50 transition-all"
+      >
+        <i className="fab fa-github"></i>
+      </a>
 
       <div 
         id="settingsModal" 
@@ -115,7 +126,10 @@ export default function SettingsModal({
               value={apiUrl}
               onChange={(e) => setApiUrl(e.target.value)}
             />
-            <p className="text-xs text-gray-500 mt-1">留空则使用默认端点。</p>
+            <p className="text-xs text-gray-500 mt-1">
+              留空则使用默认端点。若使用自定义域名，请在域名后加
+              <code className="px-1 py-0.5 bg-gray-100 rounded">v1/chat/completions</code>
+            </p>
           </div>
           
           <div className="mb-4">

--- a/app/globals.css
+++ b/app/globals.css
@@ -468,6 +468,25 @@ rb {
   transition: all 0.2s ease;
 }
 
+#githubButton {
+  position: fixed;
+  top: 1.5rem;
+  right: 5rem;
+  z-index: 1000;
+  background-color: white;
+  color: #333;
+  border: 1px solid #333;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
 @media (max-width: 640px) {
   #settingsButton {
     top: 1rem;
@@ -475,9 +494,20 @@ rb {
     width: 36px;
     height: 36px;
   }
+  #githubButton {
+    top: 1rem;
+    right: 4rem;
+    width: 36px;
+    height: 36px;
+  }
 }
 
 #settingsButton:hover {
+  background-color: #f0f2f5;
+  transform: scale(1.1);
+}
+
+#githubButton:hover {
   background-color: #f0f2f5;
   transform: scale(1.1);
 }


### PR DESCRIPTION
## Summary
- add link to the GitHub repo in the top‑right corner
- guide users to append `v1/chat/completions` when using custom domains

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684451932270832b94e0b84ea486aa75