### PR TITLE
Trigger translation alongside analysis

### DIFF
--- a/app/components/TranslationSection.tsx
+++ b/app/components/TranslationSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { translateText, streamTranslateText } from '../services/api';
 
 interface TranslationSectionProps {
@@ -8,13 +8,15 @@ interface TranslationSectionProps {
   userApiKey?: string;
   userApiUrl?: string;
   useStream?: boolean;
+  trigger?: number;
 }
 
-export default function TranslationSection({ 
+export default function TranslationSection({
   japaneseText,
   userApiKey,
   userApiUrl,
-  useStream = true // 默认为true，保持向后兼容
+  useStream = true, // 默认为true，保持向后兼容
+  trigger
 }: TranslationSectionProps) {
   const [translation, setTranslation] = useState<string>('');
   const [isLoading, setIsLoading] = useState(false);
@@ -65,6 +67,14 @@ export default function TranslationSection({
   const toggleVisibility = () => {
     setIsVisible(!isVisible);
   };
+
+  // 当trigger变化时自动开始翻译
+  useEffect(() => {
+    if (trigger && japaneseText) {
+      handleTranslate();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trigger]);
 
   return (
     <>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ export default function Home() {
   const [useStream, setUseStream] = useState<boolean>(true);
   const [streamContent, setStreamContent] = useState('');
   const [isJsonParseError, setIsJsonParseError] = useState(false);
+  const [translationTrigger, setTranslationTrigger] = useState(0);
   
   // API设置相关状态
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
@@ -163,10 +164,11 @@ export default function Home() {
 
   const handleAnalyze = async (text: string) => {
     if (!text) return;
-    
+
     setIsAnalyzing(true);
     setAnalysisError('');
     setCurrentSentence(text);
+    setTranslationTrigger(Date.now());
     setStreamContent('');
     setAnalyzedTokens([]);
     setIsJsonParseError(false);
@@ -284,12 +286,13 @@ export default function Home() {
             />
           )}
 
-          {!isAnalyzing && currentSentence && (
-            <TranslationSection 
+          {currentSentence && (
+            <TranslationSection
               japaneseText={currentSentence}
               userApiKey={userApiKey}
               userApiUrl={userApiUrl}
               useStream={useStream}
+              trigger={translationTrigger}
             />
           )}
         </main>


### PR DESCRIPTION
## Summary
- allow TranslationSection to auto-start translating via new `trigger` prop
- start translation when analysis begins and show translation during analysis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6848567d6a88832b8cd101426c8c2f75