### PR TITLE
Add Gemini TTS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 | 🔍 **智能句法标注** | 一键输出词性、假名、罗马音与语法成分 |
 | 📚 **多维词义解释** | 集合权威词典，提供精准中文释义 |
 | 🖼️ **OCR 图像识别** | 从截图或照片中提取日语文本并立即解析 |
-| 🔈 **原声 TTS 朗读** | 系统级 TTS 还原纯正日语发音 |
+| 🔈 **原声 TTS 朗读** | 集成 Gemini TTS, 朗读整段日语 |
 | 🔄 **整句翻译** | 双语对照，迅速把握整体含义 |
 | 🌐 **流式响应** | 基于流式 API，交互更丝滑 |
 | ⚙️ **高度可配置** | 支持自定义 Gemini API Key / Endpoint |
@@ -53,7 +53,21 @@ https://github.com/user-attachments/assets/5039cb62-135e-48e1-971d-960d6b82cacf
    | 变量名 | 必填 | 说明 |
    | :--- | :---: | :--- |
    | `API_KEY` | ✅ | 你的 Gemini API 密钥（前文获取的） |
-   | `API_URL` | ❌ | 自定义接口地址（留空使用默认） |
+| `API_URL` | ❌ | 自定义接口地址（留空使用默认） |
+
+### 本地 TTS 测试
+
+确认 `API_KEY` 已配置后，可在命令行运行：
+
+```bash
+curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent?key=${API_KEY}" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"contents":[{"parts":[{"text":"こんにちは"}]}],"generationConfig":{"responseModalities":["AUDIO"],"speechConfig":{"voiceConfig":{"prebuiltVoiceConfig":{"voiceName":"Kore"}}}},"model":"gemini-2.5-flash-preview-tts"}' \
+  | jq -r '.candidates[0].content.parts[0].inlineData.data' | base64 --decode >out.pcm
+ffmpeg -f s16le -ar 24000 -ac 1 -i out.pcm out.wav
+```
+
+即可得到 `out.wav` 音频文件。
 
 4. 点击 **Deploy**，几秒后即可访问专属域名 ✨
 ---

--- a/app/api/tts/route.ts
+++ b/app/api/tts/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_KEY = process.env.API_KEY || '';
+const TTS_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent';
+const MODEL_NAME = 'gemini-2.5-flash-preview-tts';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { text, voice = 'Kore', model = MODEL_NAME } = await req.json();
+
+    const authHeader = req.headers.get('Authorization');
+    const userApiKey = authHeader ? authHeader.replace('Bearer ', '') : '';
+    const effectiveApiKey = userApiKey || API_KEY;
+
+    if (!effectiveApiKey) {
+      return NextResponse.json(
+        { error: { message: '未提供API密钥，请在设置中配置API密钥或联系管理员配置服务器密钥' } },
+        { status: 500 }
+      );
+    }
+
+    if (!text) {
+      return NextResponse.json(
+        { error: { message: '缺少必要的文本内容' } },
+        { status: 400 }
+      );
+    }
+
+    const payload = {
+      contents: [{ parts: [{ text }] }],
+      generationConfig: {
+        responseModalities: ['AUDIO'],
+        speechConfig: {
+          voiceConfig: { prebuiltVoiceConfig: { voiceName: voice } }
+        }
+      },
+      model
+    };
+
+    const response = await fetch(`${TTS_URL}?key=${effectiveApiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const data = await response.json();
+      console.error('TTS API error:', data);
+      return NextResponse.json(
+        { error: data.error || { message: 'TTS 请求失败' } },
+        { status: response.status }
+      );
+    }
+
+    const result = await response.json();
+    const inlineData = result.candidates?.[0]?.content?.parts?.[0]?.inlineData;
+    if (!inlineData) {
+      return NextResponse.json(
+        { error: { message: '无有效音频数据' } },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ audio: inlineData.data, mimeType: inlineData.mimeType });
+  } catch (error) {
+    console.error('Server error (TTS):', error);
+    return NextResponse.json(
+      { error: { message: error instanceof Error ? error.message : '服务器错误' } },
+      { status: 500 }
+    );
+  }
+}

--- a/app/components/AnalysisResult.tsx
+++ b/app/components/AnalysisResult.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { containsKanji, getPosClass, posChineseMap, speakJapanese } from '../utils/helpers';
+import { containsKanji, getPosClass, posChineseMap, speakJapaneseWithTTS } from '../utils/helpers';
 import { getWordDetails, WordDetail } from '../services/api';
 
 interface TokenData {
@@ -142,7 +142,7 @@ export default function AnalysisResult({
         <button 
           className="read-aloud-button" 
           title="朗读此词汇"
-          onClick={() => speakJapanese(wordDetail?.originalWord || '')}
+          onClick={() => speakJapaneseWithTTS(wordDetail?.originalWord || '')}
         >
           <i className="fas fa-volume-up"></i>
         </button>

--- a/app/components/AnalysisResult.tsx
+++ b/app/components/AnalysisResult.tsx
@@ -9,15 +9,13 @@ interface AnalysisResultProps {
   originalSentence: string;
   userApiKey?: string;
   userApiUrl?: string;
-  ttsProvider: 'system' | 'gemini';
 }
 
 export default function AnalysisResult({ 
   tokens, 
   originalSentence,
   userApiKey,
-  userApiUrl,
-  ttsProvider
+  userApiUrl
 }: AnalysisResultProps) {
   const [wordDetail, setWordDetail] = useState<WordDetail | null>(null);
   const [activeWordToken, setActiveWordToken] = useState<HTMLElement | null>(null);
@@ -130,20 +128,10 @@ export default function AnalysisResult({
   // 朗读单词的函数
   const handleWordSpeak = async (word: string) => {
     try {
-      if (ttsProvider === 'gemini') {
-        // 从本地存储获取语音设置
-        const storedVoice = localStorage.getItem('ttsVoice') || 'Kore';
-        const storedStyle = localStorage.getItem('ttsStyle') || '';
-        const stylePrompt = storedStyle ? `Say ${storedStyle}: ` : '';
-        const textToSpeak = stylePrompt + word;
-        await speakJapaneseWithTTS(textToSpeak, userApiKey, storedVoice);
-      } else {
-        speakJapanese(word);
-      }
+      // 词汇详解中统一使用系统TTS，速度更快
+      speakJapanese(word);
     } catch (error) {
       console.error('朗读失败:', error);
-      // 如果选择的TTS失败，回退到系统TTS
-      speakJapanese(word);
     }
   };
 

--- a/app/components/AnalysisResult.tsx
+++ b/app/components/AnalysisResult.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { containsKanji, getPosClass, posChineseMap, speakJapaneseWithTTS, speakJapanese } from '../utils/helpers';
+import { containsKanji, getPosClass, posChineseMap, speakJapanese } from '../utils/helpers';
 import { getWordDetails, TokenData, WordDetail } from '../services/api';
 
 interface AnalysisResultProps {

--- a/app/components/InputSection.tsx
+++ b/app/components/InputSection.tsx
@@ -59,6 +59,17 @@ export default function InputSection({
     }
   };
 
+  // 根据文本长度估算合成时间
+  const getEstimatedTime = (text: string): string => {
+    const length = text.length;
+    if (length <= 20) return '5-10秒';
+    if (length <= 50) return '10-20秒';
+    if (length <= 100) return '20-30秒';
+    return '30-60秒';
+  };
+
+
+
   const handleImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
@@ -215,36 +226,29 @@ export default function InputSection({
           className="hidden" 
           onChange={handleImageUpload}
         />
-        <button
-          id="uploadImageButton"
-          className="premium-button premium-button-secondary w-full sm:w-auto mb-2 sm:mb-0 sm:order-1 text-sm sm:text-base py-2 sm:py-3"
-          onClick={() => document.getElementById('imageUploadInput')?.click()}
-          disabled={isImageUploading}
-        >
-          <i className="fas fa-camera mr-2"></i>
-          {!isImageUploading && <span className="button-text">上传图片提取文字</span>}
-          <div className="loading-spinner" style={{ display: isImageUploading ? 'inline-block' : 'none', width: '18px', height: '18px' }}></div>
-          {isImageUploading && <span className="button-text">提取中...</span>}
-        </button>
+        <div className="flex gap-2 w-full sm:w-auto mb-2 sm:mb-0 sm:order-1">
+          <button
+            id="uploadImageButton"
+            className="premium-button premium-button-secondary flex-1 sm:w-auto text-sm sm:text-base py-2 sm:py-3"
+            onClick={() => document.getElementById('imageUploadInput')?.click()}
+            disabled={isImageUploading}
+            title="上传图片提取文字"
+          >
+            <i className="fas fa-camera"></i>
+            {isImageUploading && <div className="loading-spinner ml-2" style={{ width: '18px', height: '18px' }}></div>}
+          </button>
 
-        <button
-          id="speakButton"
-          className="premium-button premium-button-secondary w-full sm:w-auto sm:order-2 text-sm sm:text-base py-2 sm:py-3"
-          onClick={handleSpeak}
-          disabled={!inputText.trim() || isLoading || isSpeaking}
-        >
-          <i className="fas fa-volume-up mr-2"></i>
-          {!isSpeaking && <span className="button-text">朗读文本</span>}
-          <div
-            className="loading-spinner"
-            style={{ display: isSpeaking ? 'inline-block' : 'none', width: '18px', height: '18px' }}
-          ></div>
-          {isSpeaking && <span className="button-text">生成中...</span>}
-        </button>
-
-        {ttsAudioUrl && (
-          <audio key={ttsAudioUrl} src={ttsAudioUrl} controls autoPlay className="w-full mt-2" />
-        )}
+          <button
+            id="speakButton"
+            className="premium-button premium-button-secondary flex-1 sm:w-auto text-sm sm:text-base py-2 sm:py-3"
+            onClick={handleSpeak}
+            disabled={!inputText.trim() || isLoading || isSpeaking}
+            title={inputText.trim() ? `朗读文本 (预计需要 ${getEstimatedTime(inputText)})` : '请先输入文本'}
+          >
+            <i className="fas fa-volume-up"></i>
+            {isSpeaking && <div className="loading-spinner ml-2" style={{ width: '18px', height: '18px' }}></div>}
+          </button>
+        </div>
 
         <button
           id="analyzeButton"
@@ -259,6 +263,39 @@ export default function InputSection({
       </div>
       
       <div id="imageUploadStatus" className={uploadStatusClass}>{uploadStatus}</div>
+      
+      {ttsAudioUrl && (
+        <div className="mt-3">
+          <audio 
+            key={ttsAudioUrl} 
+            src={ttsAudioUrl} 
+            controls 
+            autoPlay 
+            className="w-full"
+            style={{ height: '40px' }}
+          />
+        </div>
+      )}
+
+      {isSpeaking && (
+        <div className="mt-3 p-3 bg-blue-50 border-l-4 border-blue-500 rounded-r-lg">
+          <div className="flex items-start">
+            <div className="flex-shrink-0">
+              <i className="fas fa-info-circle text-blue-500 mt-0.5"></i>
+            </div>
+            <div className="ml-3">
+              <p className="text-sm text-blue-700">
+                <strong>正在进行高质量语音合成，请稍候...</strong>
+              </p>
+              <p className="text-xs text-blue-600 mt-1">
+                • 使用 Gemini TTS 技术，音质更自然<br/>
+                • 当前文本预计需要：{getEstimatedTime(inputText)}<br/>
+                • 请保持页面打开，不要离开或刷新
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 } 

--- a/app/components/InputSection.tsx
+++ b/app/components/InputSection.tsx
@@ -45,7 +45,7 @@ export default function InputSection({
   const handleSpeak = async () => {
     if (!inputText.trim()) return;
     try {
-      await speakJapaneseWithTTS(inputText, userApiKey, userApiUrl);
+      await speakJapaneseWithTTS(inputText, userApiKey);
     } catch (e) {
       console.error('TTS error:', e);
     }

--- a/app/components/InputSection.tsx
+++ b/app/components/InputSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { extractTextFromImage, streamExtractTextFromImage } from '../services/api';
+import { speakJapaneseWithTTS } from '../utils/helpers';
 
 // 添加内联样式
 const placeholderStyle = `
@@ -39,6 +40,15 @@ export default function InputSection({
     setIsLoading(true);
     onAnalyze(inputText);
     setTimeout(() => setIsLoading(false), 300); // 简化示例，实际应在分析完成后设置
+  };
+
+  const handleSpeak = async () => {
+    if (!inputText.trim()) return;
+    try {
+      await speakJapaneseWithTTS(inputText, userApiKey, userApiUrl);
+    } catch (e) {
+      console.error('TTS error:', e);
+    }
   };
 
   const handleImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -197,8 +207,8 @@ export default function InputSection({
           className="hidden" 
           onChange={handleImageUpload}
         />
-        <button 
-          id="uploadImageButton" 
+        <button
+          id="uploadImageButton"
           className="premium-button premium-button-secondary w-full sm:w-auto mb-2 sm:mb-0 sm:order-1 text-sm sm:text-base py-2 sm:py-3"
           onClick={() => document.getElementById('imageUploadInput')?.click()}
           disabled={isImageUploading}
@@ -208,9 +218,19 @@ export default function InputSection({
           <div className="loading-spinner" style={{ display: isImageUploading ? 'inline-block' : 'none', width: '18px', height: '18px' }}></div>
           {isImageUploading && <span className="button-text">提取中...</span>}
         </button>
-        
-        <button 
-          id="analyzeButton" 
+
+        <button
+          id="speakButton"
+          className="premium-button premium-button-secondary w-full sm:w-auto sm:order-2 text-sm sm:text-base py-2 sm:py-3"
+          onClick={handleSpeak}
+          disabled={!inputText.trim() || isLoading}
+        >
+          <i className="fas fa-volume-up mr-2"></i>
+          <span className="button-text">朗读文本</span>
+        </button>
+
+        <button
+          id="analyzeButton"
           className="premium-button premium-button-primary w-full sm:w-auto sm:order-2 text-sm sm:text-base py-2 sm:py-3"
           onClick={handleAnalyze}
           disabled={isLoading}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,15 +21,18 @@ export default function Home() {
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
   const [userApiKey, setUserApiKey] = useState('');
   const [userApiUrl, setUserApiUrl] = useState(DEFAULT_API_URL);
+  const [ttsProvider, setTtsProvider] = useState<'system' | 'gemini'>('gemini');
 
   // 从本地存储加载用户API设置
   useEffect(() => {
     const storedApiKey = localStorage.getItem('userApiKey') || '';
     const storedApiUrl = localStorage.getItem('userApiUrl') || DEFAULT_API_URL;
     const storedUseStream = localStorage.getItem('useStream');
+    const storedTtsProvider = localStorage.getItem('ttsProvider') as 'system' | 'gemini' || 'gemini';
     
     setUserApiKey(storedApiKey);
     setUserApiUrl(storedApiUrl);
+    setTtsProvider(storedTtsProvider);
     
     // 只有当明确设置了值时才更新，否则保持默认值
     if (storedUseStream !== null) {
@@ -46,6 +49,12 @@ export default function Home() {
     setUserApiKey(apiKey);
     setUserApiUrl(apiUrl);
     setUseStream(streamEnabled);
+  };
+
+  // 处理TTS提供商变更
+  const handleTtsProviderChange = (provider: 'system' | 'gemini') => {
+    setTtsProvider(provider);
+    localStorage.setItem('ttsProvider', provider);
   };
 
   // 解析流式内容中的JSON数据
@@ -229,6 +238,8 @@ export default function Home() {
             userApiKey={userApiKey}
             userApiUrl={userApiUrl}
             useStream={useStream}
+            ttsProvider={ttsProvider}
+            onTtsProviderChange={handleTtsProviderChange}
           />
 
           {isAnalyzing && (!analyzedTokens.length || !useStream) && (
@@ -283,6 +294,7 @@ export default function Home() {
               originalSentence={currentSentence}
               userApiKey={userApiKey}
               userApiUrl={userApiUrl}
+              ttsProvider={ttsProvider}
             />
           )}
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -294,7 +294,6 @@ export default function Home() {
               originalSentence={currentSentence}
               userApiKey={userApiKey}
               userApiUrl={userApiUrl}
-              ttsProvider={ttsProvider}
             />
           )}
 

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -661,4 +661,27 @@ export async function streamExtractTextFromImage(
     console.error('Error in stream extracting text from image:', error);
     onError(error instanceof Error ? error : new Error('未知错误'));
   }
-} 
+}
+
+// 使用Gemini TTS合成语音
+export async function synthesizeSpeech(
+  text: string,
+  voice = 'Kore',
+  userApiKey?: string
+): Promise<{ audio: string; mimeType: string }> {
+  const apiUrl = getApiEndpoint('/tts');
+  const headers = getHeaders(userApiKey);
+
+  const response = await fetch(apiUrl, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ text, voice })
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error?.message || 'TTS 请求失败');
+  }
+
+  return response.json();
+}

--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -1,4 +1,5 @@
 // 工具函数
+import { synthesizeSpeech } from '../services/api';
 
 // 检查字符串是否包含汉字
 export function containsKanji(text: string): boolean {
@@ -37,6 +38,26 @@ export function speakJapanese(text: string): void {
     window.speechSynthesis.speak(utterance);
   } else {
     console.warn('浏览器不支持语音朗读功能');
+  }
+}
+
+// 使用Gemini TTS朗读文本
+export async function speakJapaneseWithTTS(text: string, apiKey?: string): Promise<void> {
+  try {
+    const { audio, mimeType } = await synthesizeSpeech(text, 'Kore', apiKey);
+
+    const byteString = atob(audio);
+    const byteArray = new Uint8Array(byteString.length);
+    for (let i = 0; i < byteString.length; i++) {
+      byteArray[i] = byteString.charCodeAt(i);
+    }
+    const blob = new Blob([byteArray], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const audioElement = new Audio(url);
+    audioElement.play();
+  } catch (error) {
+    console.warn('Gemini TTS 播放失败，尝试使用系统朗读', error);
+    speakJapanese(text);
   }
 }
 

--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -42,9 +42,9 @@ export function speakJapanese(text: string): void {
 }
 
 // 使用Gemini TTS朗读文本
-export async function speakJapaneseWithTTS(text: string, apiKey?: string): Promise<void> {
+export async function speakJapaneseWithTTS(text: string, apiKey?: string, voice?: string): Promise<void> {
   try {
-    const url = await getJapaneseTtsAudioUrl(text, apiKey);
+    const url = await getJapaneseTtsAudioUrl(text, apiKey, voice);
     const audioElement = new Audio(url);
     audioElement.play();
   } catch (error) {
@@ -54,8 +54,8 @@ export async function speakJapaneseWithTTS(text: string, apiKey?: string): Promi
 }
 
 // 获取 Gemini TTS 音频 URL
-export async function getJapaneseTtsAudioUrl(text: string, apiKey?: string): Promise<string> {
-  const { audio, mimeType } = await synthesizeSpeech(text, 'Kore', apiKey);
+export async function getJapaneseTtsAudioUrl(text: string, apiKey?: string, voice: string = 'Kore'): Promise<string> {
+  const { audio, mimeType } = await synthesizeSpeech(text, voice, apiKey);
   return createPlayableUrlFromPcm(audio, mimeType);
 }
 

--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -44,14 +44,19 @@ export function speakJapanese(text: string): void {
 // 使用Gemini TTS朗读文本
 export async function speakJapaneseWithTTS(text: string, apiKey?: string): Promise<void> {
   try {
-    const { audio, mimeType } = await synthesizeSpeech(text, 'Kore', apiKey);
-    const url = createPlayableUrlFromPcm(audio, mimeType);
+    const url = await getJapaneseTtsAudioUrl(text, apiKey);
     const audioElement = new Audio(url);
     audioElement.play();
   } catch (error) {
     console.warn('Gemini TTS 播放失败，尝试使用系统朗读', error);
     speakJapanese(text);
   }
+}
+
+// 获取 Gemini TTS 音频 URL
+export async function getJapaneseTtsAudioUrl(text: string, apiKey?: string): Promise<string> {
+  const { audio, mimeType } = await synthesizeSpeech(text, 'Kore', apiKey);
+  return createPlayableUrlFromPcm(audio, mimeType);
 }
 
 // 将 Base64 PCM 数据转换为可播放的 WAV URL

--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -45,20 +45,58 @@ export function speakJapanese(text: string): void {
 export async function speakJapaneseWithTTS(text: string, apiKey?: string): Promise<void> {
   try {
     const { audio, mimeType } = await synthesizeSpeech(text, 'Kore', apiKey);
-
-    const byteString = atob(audio);
-    const byteArray = new Uint8Array(byteString.length);
-    for (let i = 0; i < byteString.length; i++) {
-      byteArray[i] = byteString.charCodeAt(i);
-    }
-    const blob = new Blob([byteArray], { type: mimeType });
-    const url = URL.createObjectURL(blob);
+    const url = createPlayableUrlFromPcm(audio, mimeType);
     const audioElement = new Audio(url);
     audioElement.play();
   } catch (error) {
     console.warn('Gemini TTS 播放失败，尝试使用系统朗读', error);
     speakJapanese(text);
   }
+}
+
+// 将 Base64 PCM 数据转换为可播放的 WAV URL
+function createPlayableUrlFromPcm(base64: string, mimeType: string): string {
+  const byteString = atob(base64);
+  const pcmData = new Uint8Array(byteString.length);
+  for (let i = 0; i < byteString.length; i++) {
+    pcmData[i] = byteString.charCodeAt(i);
+  }
+
+  const match = /rate=(\d+)/.exec(mimeType);
+  const sampleRate = match ? parseInt(match[1], 10) : 24000;
+  const numChannels = 1;
+  const byteRate = sampleRate * numChannels * 2;
+  const blockAlign = numChannels * 2;
+
+  const buffer = new ArrayBuffer(44 + pcmData.length);
+  const view = new DataView(buffer);
+
+  function writeString(off: number, str: string) {
+    for (let i = 0; i < str.length; i++) {
+      view.setUint8(off + i, str.charCodeAt(i));
+    }
+  }
+
+  writeString(0, 'RIFF');
+  view.setUint32(4, 36 + pcmData.length, true);
+  writeString(8, 'WAVE');
+  writeString(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, 16, true);
+  writeString(36, 'data');
+  view.setUint32(40, pcmData.length, true);
+
+  for (let i = 0; i < pcmData.length; i++) {
+    view.setUint8(44 + i, pcmData[i]);
+  }
+
+  const wavBlob = new Blob([view], { type: 'audio/wav' });
+  return URL.createObjectURL(wavBlob);
 }
 
 // 默认API URL

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -2,4 +2,5 @@ import assert from 'assert';
 import { getApiEndpoint } from '../app/services/api';
 
 assert.strictEqual(getApiEndpoint('/analyze'), '/api/analyze');
+assert.strictEqual(getApiEndpoint('/tts'), '/api/tts');
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- integrate Gemini TTS API with new `/api/tts` route
- provide `synthesizeSpeech` service and helper `speakJapaneseWithTTS`
- allow users to play text via new "朗读文本" button
- update README with Gemini TTS info and test example
- add regression test for `/tts` endpoint

## Testing
- `npx tsx tests/api.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_6848eef0aca4832ba197f9bff123d2e0