### PR TITLE
Add dark mode toggle

### DIFF
--- a/app/components/InputSection.tsx
+++ b/app/components/InputSection.tsx
@@ -11,6 +11,10 @@ const placeholderStyle = `
     color: rgba(0, 0, 0, 0.4) !important;
     opacity: 0.6 !important;
   }
+  .dark #japaneseInput::placeholder {
+    color: rgba(255, 255, 255, 0.6) !important;
+    opacity: 0.7 !important;
+  }
 `;
 
 interface InputSectionProps {
@@ -264,17 +268,17 @@ export default function InputSection({
       <style dangerouslySetInnerHTML={{ __html: placeholderStyle }} />
       <h2 className="text-xl sm:text-2xl font-semibold text-gray-700 mb-3 sm:mb-4">输入日语句子</h2>
       <div className="relative">
-        <textarea 
-          id="japaneseInput" 
-          className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#007AFF] focus:border-[#007AFF] transition duration-150 ease-in-out resize-none japanese-text" 
-          rows={4} 
+        <textarea
+          id="japaneseInput"
+          className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#007AFF] focus:border-[#007AFF] transition duration-150 ease-in-out resize-none japanese-text dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
+          rows={4}
           placeholder="例：今日はいい天気ですね。或上传图片识别文字。"
           value={inputText}
           onChange={(e) => setInputText(e.target.value)}
-          style={{ 
+          style={{
             fontSize: '16px', // 防止移动设备缩放
-            WebkitTextFillColor: 'black', // Safari特定修复
-            color: 'black',
+            WebkitTextFillColor: 'var(--foreground)', // Safari特定修复
+            color: 'var(--foreground)',
             fontFamily: "'Noto Sans JP', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', sans-serif"
           }}
           autoCapitalize="none"

--- a/app/components/SettingsModal.tsx
+++ b/app/components/SettingsModal.tsx
@@ -138,10 +138,10 @@ export default function SettingsModal({
             <label htmlFor="modalApiKeyInput" className="block text-sm font-medium text-gray-700 mb-1">
               自定义 API 密钥 (可选):
             </label>
-            <input 
-              type="password" 
-              id="modalApiKeyInput" 
-              className="w-full p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500" 
+            <input
+              type="password"
+              id="modalApiKeyInput"
+              className="w-full p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
               placeholder="输入您的 API 密钥"
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
@@ -152,10 +152,10 @@ export default function SettingsModal({
             <label htmlFor="modalApiUrlInput" className="block text-sm font-medium text-gray-700 mb-1">
               自定义 API URL (可选):
             </label>
-            <input 
-              type="text" 
-              id="modalApiUrlInput" 
-              className="w-full p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500" 
+            <input
+              type="text"
+              id="modalApiUrlInput"
+              className="w-full p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100"
               placeholder="例如: https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
               value={apiUrl}
               onChange={(e) => setApiUrl(e.target.value)}

--- a/app/components/SettingsModal.tsx
+++ b/app/components/SettingsModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { FaCog, FaGithub, FaSave } from 'react-icons/fa';
+import { FaCog, FaGithub, FaSave, FaMoon, FaSun } from 'react-icons/fa';
 
 interface SettingsModalProps {
   userApiKey: string;
@@ -27,12 +27,24 @@ export default function SettingsModal({
   const [streamEnabled, setStreamEnabled] = useState(useStream);
   const [status, setStatus] = useState('');
   const [statusClass, setStatusClass] = useState('');
+  const [darkMode, setDarkMode] = useState(false);
 
   useEffect(() => {
     setApiKey(userApiKey);
     setApiUrl(userApiUrl === defaultApiUrl ? '' : userApiUrl);
     setStreamEnabled(useStream);
   }, [userApiKey, userApiUrl, defaultApiUrl, useStream]);
+
+  useEffect(() => {
+    const storedTheme = localStorage.getItem('theme');
+    const isDark = storedTheme === 'dark';
+    setDarkMode(isDark);
+    if (isDark) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, []);
 
   const closeModal = () => {
     onModalClose();
@@ -59,6 +71,18 @@ export default function SettingsModal({
     setTimeout(() => closeModal(), 1500);
   };
 
+  const toggleDarkMode = () => {
+    const next = !darkMode;
+    setDarkMode(next);
+    if (next) {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  };
+
   return (
     <>
       <button
@@ -80,6 +104,15 @@ export default function SettingsModal({
       >
         <FaGithub />
       </a>
+
+      <button
+        id="themeToggleButton"
+        title="切换主题"
+        onClick={toggleDarkMode}
+        className="fixed top-6 right-36 z-1000 bg-white text-gray-800 border border-gray-800 rounded-full w-10 h-10 flex items-center justify-center shadow-md hover:bg-gray-50 transition-all"
+      >
+        {darkMode ? <FaSun /> : <FaMoon />}
+      </button>
 
       <div 
         id="settingsModal" 

--- a/app/globals.css
+++ b/app/globals.css
@@ -16,13 +16,25 @@ input, textarea {
   color: rgba(0, 0, 0, 0.4) !important;
   opacity: 0.6 !important;
 }
+.dark ::placeholder {
+  color: rgba(255, 255, 255, 0.6) !important;
+  opacity: 0.7 !important;
+}
 ::-webkit-input-placeholder {
   color: rgba(0, 0, 0, 0.4) !important;
   opacity: 0.6 !important;
 }
+.dark ::-webkit-input-placeholder {
+  color: rgba(255, 255, 255, 0.6) !important;
+  opacity: 0.7 !important;
+}
 :-ms-input-placeholder {
   color: rgba(0, 0, 0, 0.4) !important;
   opacity: 0.6 !important;
+}
+.dark :-ms-input-placeholder {
+  color: rgba(255, 255, 255, 0.6) !important;
+  opacity: 0.7 !important;
 }
 
 /* 移动端输入框优化 */
@@ -83,6 +95,13 @@ body {
 
 .dark .premium-card {
   background-color: #1f2937;
+}
+
+.dark input,
+.dark textarea {
+  background-color: #374151;
+  color: #ededed;
+  border-color: #4b5563;
 }
 
 @media (max-width: 640px) {
@@ -626,9 +645,9 @@ rb {
     
     /* Safari输入修复 - 关键修复 */
     textarea, input[type="text"] {
-      -webkit-text-fill-color: #000 !important;
+      -webkit-text-fill-color: var(--foreground) !important;
       opacity: 1 !important;
-      color: #000 !important;
+      color: var(--foreground) !important;
       -webkit-appearance: none;
       appearance: none;
       font-size: 16px !important;
@@ -641,21 +660,21 @@ rb {
 }
 
 /* 日语字体通用兼容设置 */
-textarea, 
-input[type="text"], 
+textarea,
+input[type="text"],
 .japanese-text,
 #japaneseInput {
   font-family: 'Noto Sans JP', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', 'ヒラギノ角ゴ ProN W3', sans-serif;
   -webkit-font-smoothing: antialiased;
-  color: #000;
+  color: var(--foreground);
   caret-color: #007AFF; /* 确保光标颜色可见 */
 }
 
 /* Safari专用类 */
 html.safari textarea,
 html.safari input[type="text"] {
-  -webkit-text-fill-color: black !important;
-  color: black !important;
+  -webkit-text-fill-color: var(--foreground) !important;
+  color: var(--foreground) !important;
   opacity: 1 !important;
 }
 
@@ -666,12 +685,18 @@ html.safari input::placeholder {
   opacity: 0.6 !important;
 }
 
+.dark html.safari textarea::placeholder,
+.dark html.safari input::placeholder {
+  -webkit-text-fill-color: rgba(255, 255, 255, 0.6) !important;
+  color: rgba(255, 255, 255, 0.6) !important;
+}
+
 html.safari #japaneseInput {
   font-family: -apple-system, 'Noto Sans JP', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', sans-serif !important;
   -webkit-font-smoothing: antialiased;
-  -webkit-text-fill-color: black !important;
-  color: black !important;
-  background-color: white !important;
+  -webkit-text-fill-color: var(--foreground) !important;
+  color: var(--foreground) !important;
+  background-color: transparent !important;
 }
 
 /* 词语详情模态窗口样式 */

--- a/app/globals.css
+++ b/app/globals.css
@@ -57,12 +57,20 @@ input, textarea {
   }
 }
 
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  --foreground-rgb: 255, 255, 255;
+  --background-start-rgb: 0, 0, 0;
+  --background-end-rgb: 0, 0, 0;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: Inter, 'Noto Sans JP', sans-serif;
   color: rgb(var(--foreground-rgb));
-  background-color: #f0f2f5;
+  background-color: var(--background);
 }
 
 .premium-card {
@@ -71,6 +79,10 @@ body {
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   padding: 2rem 1.5rem; /* 较小的水平内边距，适应移动设备 */
   margin-bottom: 1.5rem;
+}
+
+.dark .premium-card {
+  background-color: #1f2937;
 }
 
 @media (max-width: 640px) {
@@ -272,6 +284,12 @@ rb {
   position: relative;
 }
 
+.dark #wordDetailInlineContainer {
+  background-color: #1f2937;
+  border-color: #374151;
+  color: #ededed;
+}
+
 @media (max-width: 640px) {
   #wordDetailInlineContainer {
     padding: 1.25rem 1rem; /* 移动设备上较小的内边距 */
@@ -425,6 +443,11 @@ rb {
   animation: fadeInModal 0.3s;
 }
 
+.dark .settings-modal-content {
+  background-color: #1f2937;
+  color: #ededed;
+}
+
 @media (max-width: 640px) {
   .settings-modal-content {
     padding: 20px 15px; /* 移动设备上更小的内边距 */
@@ -487,6 +510,33 @@ rb {
   transition: all 0.2s ease;
 }
 
+#themeToggleButton {
+  position: fixed;
+  top: 1.5rem;
+  right: 9rem;
+  z-index: 1000;
+  background-color: white;
+  color: #333;
+  border: 1px solid #333;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.dark #settingsButton,
+.dark #githubButton,
+.dark #themeToggleButton {
+  background-color: #374151;
+  border-color: #555;
+  color: #ededed;
+}
+
 @media (max-width: 640px) {
   #settingsButton {
     top: 1rem;
@@ -510,6 +560,17 @@ rb {
 #githubButton:hover {
   background-color: #f0f2f5;
   transform: scale(1.1);
+}
+
+#themeToggleButton:hover {
+  background-color: #f0f2f5;
+  transform: scale(1.1);
+}
+
+.dark #settingsButton:hover,
+.dark #githubButton:hover,
+.dark #themeToggleButton:hover {
+  background-color: #4b5563;
 }
 
 /* Ruby代替样式 */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,6 +29,19 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap"
           rel="stylesheet"
         />
+        {/* 根据本地存储或系统偏好初始化主题 */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => {
+              try {
+                const t = localStorage.getItem('theme');
+                if (t === 'dark' || (!t && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                  document.documentElement.classList.add('dark');
+                }
+              } catch (_) {}
+            })();`,
+          }}
+        />
         {/* Safari输入修复脚本 */}
         <script dangerouslySetInnerHTML={{ __html: `
           (function() {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,8 @@
+export default {
+  darkMode: 'class',
+  content: ['./app/**/*.{ts,tsx,js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- enable class-based dark mode for Tailwind
- initialize theme based on `localStorage`
- allow toggling theme in settings modal
- add dark styles for cards, modals and buttons

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c432c710883269577bc1b7d7c5817