### PR TITLE
Fix mobile icon alignment

### DIFF
--- a/app/components/ThemeToggle.tsx
+++ b/app/components/ThemeToggle.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
+import { FaSun, FaMoon, FaDesktop } from 'react-icons/fa';
 import { useTheme } from '../contexts/ThemeContext';
 
 export default function ThemeToggle() {
@@ -41,7 +42,7 @@ export default function ThemeToggle() {
         onClick={() => setIsOpen(!isOpen)}
         title={`切换主题 - ${getThemeLabel()}`}
       >
-        <i className={`fas ${actualTheme === 'dark' ? 'fa-moon' : 'fa-sun'} text-lg`}></i>
+        {actualTheme === 'dark' ? <FaMoon className="text-lg" /> : <FaSun className="text-lg" />}
       </button>
 
       {isOpen && (
@@ -57,7 +58,7 @@ export default function ThemeToggle() {
                 : 'text-gray-700 dark:text-gray-300'
             }`}
           >
-            <i className="fas fa-sun text-base"></i>
+            <FaSun className="text-base" />
             <span className="text-sm font-medium">亮色模式</span>
           </button>
           
@@ -72,7 +73,7 @@ export default function ThemeToggle() {
                 : 'text-gray-700 dark:text-gray-300'
             }`}
           >
-            <i className="fas fa-moon text-base"></i>
+            <FaMoon className="text-base" />
             <span className="text-sm font-medium">暗色模式</span>
           </button>
           
@@ -87,7 +88,7 @@ export default function ThemeToggle() {
                 : 'text-gray-700 dark:text-gray-300'
             }`}
           >
-            <i className="fas fa-desktop text-base"></i>
+            <FaDesktop className="text-base" />
             <span className="text-sm font-medium">跟随系统</span>
           </button>
           

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -80,7 +80,6 @@ export default function RootLayout({
         <ThemeProvider>
           {children}
         </ThemeProvider>
-        <Script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/js/all.min.js" strategy="afterInteractive" />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- make theme toggle icons use `react-icons`
- remove unused FontAwesome script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a07d389e08326b31eedf6fda9309e