### PR TITLE
Fix word detail overlay stacking on mobile

### DIFF
--- a/app/components/InputSection.tsx
+++ b/app/components/InputSection.tsx
@@ -352,7 +352,7 @@ export default function InputSection({
         <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-white dark:from-gray-800 via-white/80 dark:via-gray-800/80 to-transparent pointer-events-none rounded-b-3xl"></div>
         
         {/* 左侧工具按钮区域 */}
-        <div className="absolute left-4 bottom-4 flex items-center gap-1 z-10">
+        <div className="absolute left-4 bottom-4 flex items-center gap-1 z-[1]">
           {/* 上传图片按钮 */}
           <button
             id="uploadImageButton"
@@ -497,7 +497,7 @@ export default function InputSection({
         </div>
         
         {/* 右侧按钮组 */}
-        <div className="absolute right-4 bottom-4 flex items-center gap-2">
+        <div className="absolute right-4 bottom-4 flex items-center gap-2 z-[1]">
           {/* 清空按钮 */}
           {inputText.trim() !== '' && (
             <button 

--- a/app/components/TranslationSection.tsx
+++ b/app/components/TranslationSection.tsx
@@ -79,9 +79,9 @@ export default function TranslationSection({
   return (
     <>
       <div className="mt-6 flex flex-col sm:flex-row sm:justify-center space-y-3 sm:space-y-0 sm:space-x-4">
-        <button 
-          id="translateSentenceButton" 
-          className="premium-button premium-button-primary w-full sm:w-auto"
+        <button
+          id="translateSentenceButton"
+          className="premium-button premium-button-primary w-full sm:w-auto z-0"
           onClick={handleTranslate}
           disabled={isLoading}
         >

--- a/app/globals.css
+++ b/app/globals.css
@@ -544,7 +544,7 @@ rb {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   animation: slideDownFadeIn 0.3s ease-out;
   position: relative;
-  z-index: 40; /* 确保在输入区域浮动按钮之上 */
+  z-index: 120; /* 确保在输入区域浮动按钮之上 */
 }
 
 @media (max-width: 640px) {
@@ -838,7 +838,7 @@ html.safari #japaneseInput {
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 1000;
+  z-index: 2000;
   padding: 15px;
   animation: fadeInModal 0.2s ease;
   will-change: opacity;


### PR DESCRIPTION
## Summary
- raise the inline word detail container stacking context so it sits above floating input controls

## Testing
- npm run dev

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d4132e28832686e3f004406fe119)