### PR TITLE
升级 Gemini 模型并默认隐藏罗马音

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 | 能力 | 默认模型 / 服务 | 说明 |
 | --- | --- | --- |
 | 文本解析 | `deepseek-v4-flash` / `deepseek-v4-pro` | 默认文本服务商是 DeepSeek，可在设置中切换 Flash / Pro；DeepSeek 请求默认关闭思考模式。 |
-| Gemini 文本解析 | `gemini-3.5-flash` / `gemini-3.1-flash-lite` | 可在设置中切换 Gemini Flash / Flash-Lite；Gemini 请求使用最低推理档。 |
+| Gemini 文本解析 | `gemini-3.6-flash` / `gemini-3.5-flash-lite` | 可在设置中切换 Gemini Flash / Flash-Lite；Gemini 请求使用最低推理档。 |
 | 图片识别 | Gemini | DeepSeek 当前不支持图片识别，选择 DeepSeek 时图片上传和粘贴识别会关闭。 |
 | 朗读 | Edge TTS / Gemini TTS | 默认使用 Edge TTS；Gemini TTS 需要 Gemini API Key。 |
 

--- a/app/lib/aiModels.ts
+++ b/app/lib/aiModels.ts
@@ -1,12 +1,12 @@
 export type AIProvider = 'gemini' | 'deepseek';
-export type GeminiModelName = 'gemini-3.5-flash' | 'gemini-3.1-flash-lite';
+export type GeminiModelName = 'gemini-3.6-flash' | 'gemini-3.5-flash-lite';
 export type DeepSeekModelName = 'deepseek-v4-flash' | 'deepseek-v4-pro';
 export type AIModelName = GeminiModelName | DeepSeekModelName;
 
 export const DEFAULT_AI_PROVIDER: AIProvider = 'deepseek';
-export const GEMINI_MODEL_NAME: GeminiModelName = 'gemini-3.5-flash';
+export const GEMINI_MODEL_NAME: GeminiModelName = 'gemini-3.6-flash';
 export const DEEPSEEK_MODEL_NAME: DeepSeekModelName = 'deepseek-v4-flash';
-export const GEMINI_MODEL_OPTIONS: GeminiModelName[] = ['gemini-3.5-flash', 'gemini-3.1-flash-lite'];
+export const GEMINI_MODEL_OPTIONS: GeminiModelName[] = ['gemini-3.6-flash', 'gemini-3.5-flash-lite'];
 export const DEEPSEEK_MODEL_OPTIONS: DeepSeekModelName[] = ['deepseek-v4-flash', 'deepseek-v4-pro'];
 
 export function normalizeAIProvider(value?: unknown): AIProvider {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,7 +35,7 @@ export default function Home() {
   const [streamContent, setStreamContent] = useState('');
   const [translationTrigger, setTranslationTrigger] = useState(0);
   const [showFurigana, setShowFurigana] = useState(true);
-  const [showRomaji, setShowRomaji] = useState(true);
+  const [showRomaji, setShowRomaji] = useState(false);
 
   // API设置相关状态
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -63,22 +63,22 @@ assert.strictEqual(SERVER_DEFAULT_AI_PROVIDER, 'deepseek');
 assert.strictEqual(getModelName(), 'deepseek-v4-flash');
 assert.strictEqual(getTtsModelName('edge'), 'edge-tts');
 assert.strictEqual(getTtsModelName('gemini'), 'gemini-3.1-flash-tts-preview');
-assert.deepStrictEqual(GEMINI_MODEL_OPTIONS, ['gemini-3.5-flash', 'gemini-3.1-flash-lite']);
+assert.deepStrictEqual(GEMINI_MODEL_OPTIONS, ['gemini-3.6-flash', 'gemini-3.5-flash-lite']);
 assert.deepStrictEqual(DEEPSEEK_MODEL_OPTIONS, ['deepseek-v4-flash', 'deepseek-v4-pro']);
 assert.strictEqual(normalizeAIProvider('gemini'), 'gemini');
 assert.strictEqual(normalizeAIProvider('deepseek'), 'deepseek');
 assert.strictEqual(normalizeAIProvider('unknown'), 'deepseek');
 assert.strictEqual(normalizeAIModel('deepseek', 'deepseek-v4-pro'), 'deepseek-v4-pro');
 assert.strictEqual(normalizeAIModel('deepseek', 'unknown'), 'deepseek-v4-flash');
-assert.strictEqual(normalizeAIModel('gemini', 'gemini-3.1-flash-lite'), 'gemini-3.1-flash-lite');
-assert.strictEqual(normalizeAIModel('gemini', 'deepseek-v4-pro'), 'gemini-3.5-flash');
+assert.strictEqual(normalizeAIModel('gemini', 'gemini-3.5-flash-lite'), 'gemini-3.5-flash-lite');
+assert.strictEqual(normalizeAIModel('gemini', 'deepseek-v4-pro'), 'gemini-3.6-flash');
 assert.strictEqual(normalizeServerAIProvider('gemini'), 'gemini');
 assert.strictEqual(normalizeServerAIProvider('deepseek'), 'deepseek');
 assert.strictEqual(normalizeServerAIProvider('unknown'), 'deepseek');
 assert.strictEqual(getModelName('deepseek'), 'deepseek-v4-flash');
 assert.strictEqual(getModelName('deepseek', 'deepseek-v4-pro'), 'deepseek-v4-pro');
-assert.strictEqual(getModelName('gemini', 'gemini-3.1-flash-lite'), 'gemini-3.1-flash-lite');
-assert.strictEqual(getModelName('gemini', 'deepseek-v4-pro'), 'gemini-3.5-flash');
+assert.strictEqual(getModelName('gemini', 'gemini-3.5-flash-lite'), 'gemini-3.5-flash-lite');
+assert.strictEqual(getModelName('gemini', 'deepseek-v4-pro'), 'gemini-3.6-flash');
 
 const oldCode = process.env.CODE;
 try {
@@ -123,7 +123,7 @@ assert.deepStrictEqual(getAnalyzeUsageEvent('gemini'), {
   name: ANALYZE_USAGE_EVENT_NAME,
   data: {
     provider: 'gemini',
-    model: 'gemini-3.5-flash',
+    model: 'gemini-3.6-flash',
     image_recognition: 'false',
     image_provider: 'none',
     image_model: 'none',
@@ -132,11 +132,11 @@ assert.deepStrictEqual(getAnalyzeUsageEvent('gemini'), {
     tts_model: 'none',
   },
 });
-assert.deepStrictEqual(getAnalyzeUsageEvent('gemini', {}, 'gemini-3.1-flash-lite'), {
+assert.deepStrictEqual(getAnalyzeUsageEvent('gemini', {}, 'gemini-3.5-flash-lite'), {
   name: ANALYZE_USAGE_EVENT_NAME,
   data: {
     provider: 'gemini',
-    model: 'gemini-3.1-flash-lite',
+    model: 'gemini-3.5-flash-lite',
     image_recognition: 'false',
     image_provider: 'none',
     image_model: 'none',
@@ -179,10 +179,10 @@ assert.deepStrictEqual(getAnalyzeUsageEvent('gemini', {
   name: ANALYZE_USAGE_EVENT_NAME,
   data: {
     provider: 'gemini',
-    model: 'gemini-3.5-flash',
+    model: 'gemini-3.6-flash',
     image_recognition: 'true',
     image_provider: 'gemini',
-    image_model: 'gemini-3.5-flash',
+    image_model: 'gemini-3.6-flash',
     tts: 'true',
     tts_provider: 'gemini',
     tts_model: 'gemini-3.1-flash-tts-preview',
@@ -192,7 +192,7 @@ assert.deepStrictEqual(getImageRecognitionUsageEvent('gemini'), {
   name: IMAGE_RECOGNITION_USAGE_EVENT_NAME,
   data: {
     provider: 'gemini',
-    model: 'gemini-3.5-flash',
+    model: 'gemini-3.6-flash',
   },
 });
 assert.deepStrictEqual(getTtsUsageEvent('edge'), {
@@ -254,12 +254,12 @@ assert.strictEqual(normalizeEscapedLineBreaks('第一行\\\\n第二行'), '第�
 
 assert.deepStrictEqual(getRequestProviderPayload('gemini'), {
   provider: 'gemini',
-  model: 'gemini-3.5-flash',
+  model: 'gemini-3.6-flash',
 });
 
-assert.deepStrictEqual(getRequestProviderPayload('gemini', 'gemini-3.1-flash-lite'), {
+assert.deepStrictEqual(getRequestProviderPayload('gemini', 'gemini-3.5-flash-lite'), {
   provider: 'gemini',
-  model: 'gemini-3.1-flash-lite',
+  model: 'gemini-3.5-flash-lite',
 });
 
 assert.deepStrictEqual(getRequestProviderPayload('deepseek'), {
@@ -277,13 +277,13 @@ assert.deepStrictEqual(getRequestProviderPayload(), {
   model: 'deepseek-v4-flash',
 });
 
-assert.deepStrictEqual(withProviderControls('gemini', { model: 'gemini-3.5-flash' }), {
-  model: 'gemini-3.5-flash',
+assert.deepStrictEqual(withProviderControls('gemini', { model: 'gemini-3.6-flash' }), {
+  model: 'gemini-3.6-flash',
   reasoning_effort: 'minimal',
 });
 
-assert.deepStrictEqual(withProviderControls('gemini', { model: 'gemini-3.1-flash-lite' }), {
-  model: 'gemini-3.1-flash-lite',
+assert.deepStrictEqual(withProviderControls('gemini', { model: 'gemini-3.5-flash-lite' }), {
+  model: 'gemini-3.5-flash-lite',
   reasoning_effort: 'minimal',
 });
 
@@ -319,7 +319,7 @@ assert.deepStrictEqual(withProviderControls(
 
 const geminiStructuredPayload = withProviderControls(
   'gemini',
-  { model: 'gemini-3.5-flash' },
+  { model: 'gemini-3.6-flash' },
   { structuredOutput: 'analysisTokens' }
 );
 assert.strictEqual(geminiStructuredPayload.reasoning_effort, 'minimal');
@@ -478,19 +478,19 @@ try {
   );
   assert.strictEqual(defaultGeminiConfig.apiKey, '');
   assert.strictEqual(defaultGeminiConfig.apiUrl, GEMINI_OPENAI_API_URL);
-  assert.strictEqual(defaultGeminiConfig.model, 'gemini-3.5-flash');
+  assert.strictEqual(defaultGeminiConfig.model, 'gemini-3.6-flash');
 
   const liteGeminiConfig = resolveProviderConfig(
     createProviderConfigRequest(),
-    { provider: 'gemini', model: 'gemini-3.1-flash-lite' }
+    { provider: 'gemini', model: 'gemini-3.5-flash-lite' }
   );
-  assert.strictEqual(liteGeminiConfig.model, 'gemini-3.1-flash-lite');
+  assert.strictEqual(liteGeminiConfig.model, 'gemini-3.5-flash-lite');
 
   const invalidGeminiConfig = resolveProviderConfig(
     createProviderConfigRequest(),
     { provider: 'gemini', model: 'deepseek-v4-pro' }
   );
-  assert.strictEqual(invalidGeminiConfig.model, 'gemini-3.5-flash');
+  assert.strictEqual(invalidGeminiConfig.model, 'gemini-3.6-flash');
 
   process.env.GEMINI_API_KEY = 'gemini-key';
   process.env.GEMINI_API_URL = 'https://gemini.example/chat/completions';
@@ -559,9 +559,9 @@ assert.strictEqual(defaultSettings.deepseekApiKey, '');
 
 const geminiLiteStorage = new MemoryStorage({
   aiProvider: 'gemini',
-  aiModel: 'gemini-3.1-flash-lite',
+  aiModel: 'gemini-3.5-flash-lite',
 });
-assert.strictEqual(loadAISettingsFromStorage(geminiLiteStorage).aiModel, 'gemini-3.1-flash-lite');
+assert.strictEqual(loadAISettingsFromStorage(geminiLiteStorage).aiModel, 'gemini-3.5-flash-lite');
 
 runOpenAIContentStreamTests()
   .then(() => {


### PR DESCRIPTION
## 变更内容

- 将解析结果中的“显示罗马音”改为默认关闭，用户仍可手动开启。
- 将 Gemini 文本模型升级为 `gemini-3.6-flash` 和 `gemini-3.5-flash-lite`。
- 同步更新 README、模型白名单、默认模型以及相关测试断言。

## 变更原因

Google 已发布新的稳定版 Gemini Flash 与 Flash-Lite 模型；同时默认隐藏罗马音可以减少解析结果中的视觉干扰，更适合已有一定日语基础的使用场景。

## 用户影响

- 解析结果首次显示时不会展示罗马音，但开关功能保持不变。
- Gemini 设置中的可选模型更新为最新稳定版本。
- 不影响 DeepSeek 与 TTS 模型配置。

## 验证

- `npm test`：通过
- `npm run lint`：0 个错误；存在 1 个与本次修改无关的既有未使用函数警告
- `npm run build`：通过
- 内置浏览器实测 `gemini-3.6-flash` 可成功完成解析，罗马音开关初始为关闭，控制台无错误