### PR TITLE
添加首次访问示例引导

### DIFF
--- a/app/components/InputSection.tsx
+++ b/app/components/InputSection.tsx
@@ -56,6 +56,9 @@ const TTS_STYLES = [
   { value: 'clearly', label: '清晰朗读', prompt: 'Say clearly: ' },
 ];
 
+const FIRST_VISIT_EXAMPLE_KEY = 'japaneseAnalyzer:firstVisitExampleSeen';
+const FIRST_VISIT_EXAMPLE = '天気がいいから、散歩しましょう';
+
 export default function InputSection({
   onAnalyze,
   userApiKey,
@@ -79,6 +82,7 @@ export default function InputSection({
   const [selectedVoice, setSelectedVoice] = useState('Kore');
   const [selectedStyle, setSelectedStyle] = useState('');
   const [submitState, setSubmitState] = useState<StateMorphButtonState>('idle');
+  const [showFirstVisitExample, setShowFirstVisitExample] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const submitStartedRef = useRef(false);
   const wasAnalyzingRef = useRef(false);
@@ -119,6 +123,21 @@ export default function InputSection({
         clearTimeout(submitResetTimerRef.current);
       }
     };
+  }, []);
+
+  // 仅在当前浏览器第一次进入网站时展示示例引导。
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(FIRST_VISIT_EXAMPLE_KEY) !== 'true') {
+        setInputText(FIRST_VISIT_EXAMPLE);
+        setShowFirstVisitExample(true);
+        localStorage.setItem(FIRST_VISIT_EXAMPLE_KEY, 'true');
+      }
+    } catch {
+      // localStorage 不可用时仍展示一次当前会话内的引导。
+      setInputText(FIRST_VISIT_EXAMPLE);
+      setShowFirstVisitExample(true);
+    }
   }, []);
 
   // 从本地存储加载TTS设置
@@ -166,6 +185,7 @@ export default function InputSection({
 
   const handleInputTextChange = (value: string) => {
     setInputText(value);
+    setShowFirstVisitExample(false);
 
     if (!value.trim()) {
       clearUsageMetadata();
@@ -197,15 +217,20 @@ export default function InputSection({
     trackTtsUsage(provider);
   };
 
-  const handleAnalyze = () => {
-    if (!inputText.trim()) {
+  const startAnalysis = (text: string, usage: AnalyzeUsageMetadata) => {
+    if (!text.trim()) {
       alert('请输入日语句子！');
       return;
     }
 
     submitStartedRef.current = true;
     setSubmitState('loading');
-    onAnalyze(inputText, getCurrentUsageMetadata());
+    onAnalyze(text, usage);
+  };
+
+  const handleAnalyze = () => {
+    setShowFirstVisitExample(false);
+    startAnalysis(inputText, getCurrentUsageMetadata());
   };
 
   const handleSpeak = async () => {
@@ -440,21 +465,32 @@ export default function InputSection({
     <div className="w-full">
       <section className="nd-card">
         <div className="relative">
+          {showFirstVisitExample && (
+            <div className="first-visit-example-kicker">
+              第一次来？从这个句子开始
+            </div>
+          )}
           <textarea
             id="japaneseInput"
             lang="ja"
-            className={`jp w-full resize-none border-none bg-transparent outline-none ${showInputShimmer ? 'input-text-shimmer-source' : ''}`}
+            className={`jp w-full resize-none border-none bg-transparent outline-none ${showFirstVisitExample ? 'first-visit-example-input' : ''} ${showInputShimmer ? 'input-text-shimmer-source' : ''}`}
             rows={5}
             placeholder="输入日语句子"
             value={inputText}
             onChange={(e) => handleInputTextChange(e.target.value)}
             onPaste={handlePaste}
             style={inputTextStyle}
+            aria-describedby={showFirstVisitExample ? 'firstVisitExampleHint' : undefined}
             autoCapitalize="none"
             autoComplete="off"
             autoCorrect="off"
             spellCheck="false"
           ></textarea>
+          {showFirstVisitExample && (
+            <div id="firstVisitExampleHint" className="first-visit-example-hint" role="status">
+              点击提交试试
+            </div>
+          )}
           {showInputShimmer && (
             <div className="input-text-shimmer-layer-frame" aria-hidden="true" lang="ja">
               <TextShimmer
@@ -636,6 +672,7 @@ export default function InputSection({
               onClick={() => {
                 setInputText('');
                 setTtsAudioUrl(null);
+                setShowFirstVisitExample(false);
                 clearUsageMetadata();
               }}
               title="清空内容"
@@ -650,6 +687,7 @@ export default function InputSection({
             onClick={handleAnalyze}
             disabled={isLoading}
             state={submitState}
+            className={showFirstVisitExample ? 'first-visit-submit-cue' : undefined}
           />
         </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -97,6 +97,78 @@ body {
   }
 }
 
+/* ========== 首次访问示例 ========== */
+.first-visit-example-kicker {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  color: var(--ink-3);
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  line-height: 1.3;
+  pointer-events: none;
+  animation: firstVisitExampleReveal 0.42s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+#japaneseInput.first-visit-example-input {
+  padding-top: 30px;
+}
+
+.first-visit-example-hint {
+  position: absolute;
+  bottom: 6px;
+  left: 0;
+  z-index: 1;
+  padding: 7px 12px;
+  border: 1px solid color-mix(in oklab, var(--primary) 18%, transparent);
+  border-radius: 999px;
+  background: var(--primary-soft);
+  color: var(--primary);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.2;
+  pointer-events: none;
+  animation: firstVisitExampleReveal 0.42s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.first-visit-submit-cue {
+  animation: firstVisitSubmitCue 1.8s ease-in-out infinite;
+}
+
+@keyframes firstVisitExampleReveal {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes firstVisitSubmitCue {
+  0%, 100% {
+    box-shadow:
+      0 0 0 0 color-mix(in oklab, var(--primary) 22%, transparent),
+      0 4px 14px -4px rgba(109, 76, 219, 0.55);
+  }
+  50% {
+    box-shadow:
+      0 0 0 8px transparent,
+      0 4px 18px -3px rgba(109, 76, 219, 0.7);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .first-visit-example-kicker,
+  .first-visit-example-hint,
+  .first-visit-submit-cue {
+    animation: none;
+  }
+}
+
 /* ========== 按钮 ========== */
 .nd-icon-btn {
   width: 40px;


### PR DESCRIPTION
## 改动内容

- 首次访问时自动预填日语示例句 `天気がいいから、散歩しましょう`
- 在输入框中显示“第一次来？从这个句子开始”和“点击提交试试”提示
- 对提交按钮增加轻量呼吸强调，引导用户完成首次解析
- 用户修改、清空或提交内容后收起引导
- 使用 `localStorage` 保证同一浏览器只展示一次
- 适配暗色主题、移动端和 `prefers-reduced-motion`

## 原因与影响

新用户进入页面后，空输入框缺少明确的起步路径。新增引导让用户无需准备自己的句子即可理解输入与提交的核心流程，不影响后续正常输入、图片识别或语音功能。

## 验证

- `npm test`
- `npm run lint`（通过；仅保留 `.codex-dev/benchmark-deepseek-v4-pro.mjs` 中已有的未使用函数警告）
- `npm run build`
- 浏览器验证首次展示、输入框聚焦不丢失提示、提交按钮强调以及刷新后不重复展示
- UTF-8 无 BOM 与 `git diff --check`